### PR TITLE
Restrict constructor parsing to only when followed by left brace

### DIFF
--- a/shared/src/main/scala/com/financialforce/oparser/Types.scala
+++ b/shared/src/main/scala/com/financialforce/oparser/Types.scala
@@ -369,7 +369,7 @@ object Parse {
     index = newIndex
     md.add(typeRef)
 
-    if (tokens.matches(index, Tokens.LParenStr)) {
+    if (nextToken.matches(Tokens.LBraceStr) && tokens.matches(index, Tokens.LParenStr)) {
       (true, addConstructor(index, tokens, md, ctd).toSeq)
     } else if (tokens.findIndex(index, token => token.matches(Tokens.EqualsStr)) != -1) {
       // Consume fields in one go

--- a/shared/src/test/scala/com/financialforce/oparser/SmokeTest.scala
+++ b/shared/src/test/scala/com/financialforce/oparser/SmokeTest.scala
@@ -152,4 +152,46 @@ class SmokeTest extends AnyFunSpec {
     assert(method.modifiers sameElements Array(Modifier("public")))
   }
 
+  it("errors on constructor without body terminated with semi-colon") {
+    val content =
+      """public class Dummy {
+        |  public Dummy();
+        |}
+        |""".stripMargin
+
+    val thrown = intercept[Exception] {
+      parse(content)
+    }
+    assert(thrown.getMessage == "Unrecognised method [2.3 -> 2.16] public Dummy ( )")
+  }
+
+  it("errors on constructor without body terminated with comment & semi-colon") {
+    val content =
+      """public class Dummy {
+        |  public Dummy()
+        |  /* A comment */
+        |  ;
+        |}
+        |""".stripMargin
+
+    val thrown = intercept[Exception] {
+      parse(content)
+    }
+    assert(thrown.getMessage == "Unrecognised method [2.3 -> 2.16] public Dummy ( )")
+  }
+
+
+  it("errors on constructor without body terminated by class end") {
+    val content =
+      """public class Dummy {
+        |  public Dummy()
+        |}
+        |""".stripMargin
+
+    val thrown = intercept[Exception] {
+      parse(content)
+    }
+    assert(thrown.getMessage == "Unexpected '}'")
+  }
+
 }


### PR DESCRIPTION
Class member parsing is invoked either when we hit a `;` or `{`, for constructors we require a block and so we can gate the constructor parse clause on the current token being `{`. If a `;` is hit before `{` then the class member parser will attempt to parse as one of the other types of class members and fail when presented with a constructor without a body.