### PR TITLE
Bump apex-parser to 5.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,13 @@
 
 ### Build & dependencies
 
-- Removed the `apex-ls` test dependency. The JVM comparison test suite now uses `apex-parser` (5.x) directly via `ApexParserFactory`, eliminating the outline-parser ↔ apex-ls cycle. JS-side sample comparison is dropped; the JS test suite is reduced to `SmokeTest`.
+- Removed the `apex-ls` test dependency. The JVM comparison test suite now uses `apex-parser 5.1.0-beta.1` directly via `ApexParserFactory`, eliminating the outline-parser ↔ apex-ls cycle. JS-side sample comparison is dropped; the JS test suite is reduced to `SmokeTest`.
 - Upgraded Scala.js to `1.18.2`.
 - Updated sbt and plugin dependencies to latest stable versions.
 
 ### JS / NPM
 
-- Bumped peer `@apexdevtools/apex-parser` to `^5.0.0` (was `^4.3.1`).
+- Bumped dev dep `@apexdevtools/apex-parser` to `^5.1.0-beta.1` (was `^4.3.1`).
 - Raised minimum Node version to `^20.19.0 || ^22.13.0 || >=24` (was `>=14.0.0`), matching the requirements of `apex-parser 5.x`.
 - Moved `@apexdevtools/apex-parser` to `devDependencies`.
 

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform)
     build       := buildJVM.value,
     Test / fork := true,
     libraryDependencies ++= Seq(
-      "io.github.apex-dev-tools" % "apex-parser"                % "5.0.0" % Test,
+      "io.github.apex-dev-tools" % "apex-parser"                % "5.1.0-beta.1" % Test,
       "org.scala-lang.modules"  %% "scala-parallel-collections" % "1.0.4" % Test
     ),
     packageOptions += Package.ManifestAttributes(

--- a/js/npm/package-lock.json
+++ b/js/npm/package-lock.json
@@ -6,16 +6,16 @@
     "": {
       "name": "@apexdevtools/outline-parser",
       "devDependencies": {
-        "@apexdevtools/apex-parser": "^5.0.0"
+        "@apexdevtools/apex-parser": "^5.1.0-beta.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@apexdevtools/apex-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@apexdevtools/apex-parser/-/apex-parser-5.0.0.tgz",
-      "integrity": "sha512-C29uPVrcZOsnk/irA2BkL9uerpfWlT0oyedhSooGE6QPeZvGw04XGHKKUdTHfUouwse3/UgWubQ6PN5rtq/a+g==",
+      "version": "5.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@apexdevtools/apex-parser/-/apex-parser-5.1.0-beta.1.tgz",
+      "integrity": "sha512-IBuDgIMNypFJ9KXQDPZ44tbroj7Qi+to+l7fTqz+PiiXSw1MRFJfIPznO0oZcY68rohyEaMfeLWG2fYAPNc7hQ==",
       "bundleDependencies": [
         "antlr4"
       ],
@@ -25,7 +25,7 @@
         "antlr4": "4.13.2"
       },
       "engines": {
-        "node": ">=20.19.0 || >=22.12.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@apexdevtools/apex-parser/node_modules/antlr4": {
@@ -40,9 +40,9 @@
   },
   "dependencies": {
     "@apexdevtools/apex-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@apexdevtools/apex-parser/-/apex-parser-5.0.0.tgz",
-      "integrity": "sha512-C29uPVrcZOsnk/irA2BkL9uerpfWlT0oyedhSooGE6QPeZvGw04XGHKKUdTHfUouwse3/UgWubQ6PN5rtq/a+g==",
+      "version": "5.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@apexdevtools/apex-parser/-/apex-parser-5.1.0-beta.1.tgz",
+      "integrity": "sha512-IBuDgIMNypFJ9KXQDPZ44tbroj7Qi+to+l7fTqz+PiiXSw1MRFJfIPznO0oZcY68rohyEaMfeLWG2fYAPNc7hQ==",
       "dev": true,
       "requires": {
         "antlr4": "4.13.2"

--- a/js/npm/package.json
+++ b/js/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apexdevtools/outline-parser",
   "devDependencies": {
-    "@apexdevtools/apex-parser": "^5.0.0"
+    "@apexdevtools/apex-parser": "^5.1.0-beta.1"
   },
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"

--- a/jvm/src/test/scala/io/github/apexdevtools/oparser/testutil/AntlrParser.scala
+++ b/jvm/src/test/scala/io/github/apexdevtools/oparser/testutil/AntlrParser.scala
@@ -8,7 +8,7 @@ import io.github.apexdevtools.oparser._
 import io.github.apexdevtools.oparser.testutil.AntlrOps._
 import io.github.apexdevtools.types.base._
 import io.github.apexdevtools.types.{ITypeDeclaration, base}
-import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
+import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.tree.TerminalNode
 
 import scala.collection.immutable.ArraySeq
@@ -27,12 +27,9 @@ object AntlrParser {
   def parse(path: String, contents: Array[Byte]): Option[ITypeDeclaration] = {
     val stream        = CharStreams.fromString(new String(contents, "UTF-8"))
     val errorListener = new CollectingErrorListener
-    val lexer         = ApexParserFactory.createLexer(stream)
-    lexer.addErrorListener(errorListener)
-    val parser = ApexParserFactory.createParser(new CommonTokenStream(lexer))
-    parser.addErrorListener(errorListener)
+    val parserPair    = ApexParserFactory.createLexerAndParser(stream, errorListener)
 
-    val cu = parser.compilationUnit()
+    val cu = parserPair.getParser.compilationUnit()
     errorListener.firstError.foreach(msg => throw new Exception(msg))
 
     val td = cu.typeDeclaration()


### PR DESCRIPTION
## Summary

- Bumps the test/dev dep on `apex-parser` from `5.0.0` to `5.1.0-beta.1` (JVM `build.sbt` + npm `package.json`).
- Picks up the new `MultilineStringLiteral` token, fully-qualified enum values in switch `when`, SOQL `GROUP BY` functions, and SOSL `WITH DIVISION` bind variables.
- Simplifies `AntlrParser` to use the new `ApexParserFactory.createLexerAndParser` helper (added post-5.0.0) in place of the inline create-listener-attach pattern.

## Test plan

- [x] `sbt scalafmtCheckAll`
- [x] `sbt parserJVM/Test/compile parserJS/Test/compile`
- [x] `SAMPLES=~/adt/apex-samples sbt parserJVM/test` — 6314 tests pass
- [x] `sbt parserJS/test` — 52 tests pass
- [ ] CI green