### PR TITLE
Fix Maven publish workflow + bump CI actions

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: 17
@@ -22,7 +22,7 @@ jobs:
 
     - uses: sbt/setup-sbt@v1
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: 22
 
@@ -33,7 +33,7 @@ jobs:
       run: sbt build
 
     - name: Checkout samples repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         repository: apex-dev-tools/apex-samples

--- a/.github/workflows/PublishMaven.yml
+++ b/.github/workflows/PublishMaven.yml
@@ -10,18 +10,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history/tags
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
+          cache: 'sbt'
 
-      - uses: actions/setup-node@v4
+      - uses: sbt/setup-sbt@v1
+
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 22
 
       - name: Publish package
         run: sbt ci-release


### PR DESCRIPTION
## Summary

- `PublishMaven.yml` was failing with `sbt: command not found` — the `ubuntu-latest` runner image no longer ships sbt preinstalled. Add `sbt/setup-sbt@v1` to match `Build.yml`.
- Bump action versions across both workflows to clear the Node.js 20 deprecation warnings: `actions/checkout` v4 → v6, `actions/setup-java` v4 → v5, `actions/setup-node` v4 → v6.
- `PublishMaven.yml`: Java 8 → 11 (matches the apex-parser publish workflow), Node 16 → 22. Bytecode target stays Java 8 via the `-source 8 -target 8` `javacOptions` in `build.sbt`.

## Test plan

- [ ] CI green on this PR (Build.yml runs against the same setup-sbt path Maven publish will use)
- [ ] After merge, re-run **Publish to Maven** workflow on the existing `v2.0.0-beta.1` tag (or whatever tag you cut) and confirm `sbt ci-release` runs to completion