### PR TITLE
chore: release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # outline-parser - Changelog
 
-## 2.0.0-beta.1
+## 2.0.0 - 2026-07-03
 
 ### General
 
@@ -27,13 +27,13 @@
 
 ### Build & dependencies
 
-- Removed the `apex-ls` test dependency. The JVM comparison test suite now uses `apex-parser 5.1.0-beta.1` directly via `ApexParserFactory`, eliminating the outline-parser ↔ apex-ls cycle. JS-side sample comparison is dropped; the JS test suite is reduced to `SmokeTest`.
+- Removed the `apex-ls` test dependency. The JVM comparison test suite now uses `apex-parser 5.1.0` directly via `ApexParserFactory`, eliminating the outline-parser ↔ apex-ls cycle. JS-side sample comparison is dropped; the JS test suite is reduced to `SmokeTest`.
 - Upgraded Scala.js to `1.18.2`.
 - Updated sbt and plugin dependencies to latest stable versions.
 
 ### JS / NPM
 
-- Bumped dev dep `@apexdevtools/apex-parser` to `^5.1.0-beta.1` (was `^4.3.1`).
+- Bumped dev dep `@apexdevtools/apex-parser` to `^5.1.0` (was `^4.3.1`).
 - Raised minimum Node version to `^20.19.0 || ^22.13.0 || >=24` (was `>=14.0.0`), matching the requirements of `apex-parser 5.x`.
 - Moved `@apexdevtools/apex-parser` to `devDependencies`.
 

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform)
     build       := buildJVM.value,
     Test / fork := true,
     libraryDependencies ++= Seq(
-      "io.github.apex-dev-tools" % "apex-parser"                % "5.1.0-beta.1" % Test,
+      "io.github.apex-dev-tools" % "apex-parser"                % "5.1.0" % Test,
       "org.scala-lang.modules"  %% "scala-parallel-collections" % "1.0.4" % Test
     ),
     packageOptions += Package.ManifestAttributes(

--- a/js/npm/package-lock.json
+++ b/js/npm/package-lock.json
@@ -6,16 +6,16 @@
     "": {
       "name": "@apexdevtools/outline-parser",
       "devDependencies": {
-        "@apexdevtools/apex-parser": "^5.1.0-beta.1"
+        "@apexdevtools/apex-parser": "^5.1.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@apexdevtools/apex-parser": {
-      "version": "5.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@apexdevtools/apex-parser/-/apex-parser-5.1.0-beta.1.tgz",
-      "integrity": "sha512-IBuDgIMNypFJ9KXQDPZ44tbroj7Qi+to+l7fTqz+PiiXSw1MRFJfIPznO0oZcY68rohyEaMfeLWG2fYAPNc7hQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@apexdevtools/apex-parser/-/apex-parser-5.1.0.tgz",
+      "integrity": "sha512-DPThB5oMnJ9b62weMpufGQfJjtZ+5UHP5Ne8nOqsDDCAVP3P2yRL80p1qX5BpPxyOowhTJ9RF/3qhat0vCrv4g==",
       "bundleDependencies": [
         "antlr4"
       ],
@@ -40,9 +40,9 @@
   },
   "dependencies": {
     "@apexdevtools/apex-parser": {
-      "version": "5.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@apexdevtools/apex-parser/-/apex-parser-5.1.0-beta.1.tgz",
-      "integrity": "sha512-IBuDgIMNypFJ9KXQDPZ44tbroj7Qi+to+l7fTqz+PiiXSw1MRFJfIPznO0oZcY68rohyEaMfeLWG2fYAPNc7hQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@apexdevtools/apex-parser/-/apex-parser-5.1.0.tgz",
+      "integrity": "sha512-DPThB5oMnJ9b62weMpufGQfJjtZ+5UHP5Ne8nOqsDDCAVP3P2yRL80p1qX5BpPxyOowhTJ9RF/3qhat0vCrv4g==",
       "dev": true,
       "requires": {
         "antlr4": "4.13.2"

--- a/js/npm/package.json
+++ b/js/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apexdevtools/outline-parser",
   "devDependencies": {
-    "@apexdevtools/apex-parser": "^5.1.0-beta.1"
+    "@apexdevtools/apex-parser": "^5.1.0"
   },
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"


### PR DESCRIPTION
Release prep for **v2.0.0** (final). Closes #32.

Promotes `v2.0.0-beta.1` to final and picks up the released **apex-parser 5.1.0** (test/dev-only dependency).

## Changes
- **CHANGELOG**: `2.0.0-beta.1` → `## 2.0.0 - 2026-07-03`; the two `apex-parser 5.1.0-beta.1` mentions updated to `5.1.0`.
- **apex-parser test dep** `5.1.0-beta.1 → 5.1.0`: `build.sbt` (JVM `Test` scope), `js/npm/package.json` (`^5.1.0`), and regenerated `js/npm/package-lock.json`.

apex-parser is test/dev-only here, so this doesn't change the published outline-parser artifacts — only the test toolchain.

## Validation (matches CI Build.yml)
- `sbt scalafmtCheck` → success
- `sbt build` → success (JS + JVM)
- `SAMPLES=apex-samples@v1.4.0 sbt test` → **6314 tests passed, 0 failed**

## Release gate
apex-ls already pins `outline-parser 2.0.0-beta.1` (build.sbt), so downstream integration is validated — 2.0.0 final is unblocked per the release-coordination plan.

## After merge
Create GitHub Release `v2.0.0` (non-prerelease) → triggers `PublishMaven.yml` (`sbt ci-release`) publishing `2.0.0` to Maven Central (JS + JVM). Then follow-up on `main` if a next dev version is wanted.