### PR TITLE
chore: standardize JDK 17 toolchain

### DIFF
--- a/.github/workflows/PublishMaven.yml
+++ b/.github/workflows/PublishMaven.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           cache: 'sbt'
 
       - uses: sbt/setup-sbt@v1

--- a/build.sbt
+++ b/build.sbt
@@ -22,9 +22,6 @@ ThisBuild / versionScheme := Some("strict")
 ThisBuild / resolvers += Resolver.mavenLocal
 ThisBuild / resolvers += Resolver.sonatypeCentralSnapshots
 
-// Java 17 development with Java 8 runtime compatibility
-ThisBuild / javacOptions ++= Seq("-source", "8", "-target", "8")
-
 lazy val build      = taskKey[File]("Build artifacts")
 lazy val pack       = inputKey[Unit]("Publish specific local version")
 lazy val npmInstall = taskKey[Unit]("Install Node modules for Scala.js tasks")
@@ -47,6 +44,8 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform)
     )
   )
   .jvmSettings(
+    javacOptions ++= Seq("--release", "8"),
+    scalacOptions ++= Seq("-release", "8"),
     build       := buildJVM.value,
     Test / fork := true,
     libraryDependencies ++= Seq(


### PR DESCRIPTION
## Summary

- align the Maven publishing workflow with the build workflow on JDK 17
- replace JVM `javac -source 8 -target 8` with `javac --release 8`
- add Scala 2.13 `-release 8` to the JVM project only, leaving Scala.js compiler settings unchanged

This makes build and publishing consistent while enforcing Java 8 platform API and bytecode compatibility for JVM artifacts.

No changelog entry is included because this changes build/CI enforcement and not user-facing behavior.

## Validation

Using JDK 17.0.20:

- `sbt build`
- `SAMPLES=/Users/kevinjones/adt/apex-samples sbt test` after restarting the pre-existing sbt server so it inherited the environment; 6,314 JVM tests and 52 Scala.js tests passed
- inspected all 92 emitted production JVM class files: every class has major version 52

The pinned sample checkout remained clean and detached at v1.4.0.
