### PR TITLE
Add stable rule IDs to issue API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # outline-parser - Changelog
 
+## Unreleased
+
+### API
+
+- Added `Rule.id()` as a stable machine-readable rule identifier on JVM and Scala.js. Existing implementations remain compatible and default to `name()`; new rules should override it with a stable lowercase kebab-case ID. Existing `Issue` string output remains unchanged.
+
 ## 2.0.0 - 2026-07-03
 
 ### General

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ Maven:
 
 The library does not currently provide a documented API. To understand how to use it we recommend looking at the test class `ApexParserCompare.scala` which is used to compare the output with our [full parser](https://github.com/apex-dev-tools/apex-parser) for Apex.
 
+### Issue API
+
+The cross-platform `io.github.apexdevtools.api.Rule` API exposes two descriptions of a rule:
+
+* `id()` is the stable machine-readable key. New rules should override it with a lowercase kebab-case value and must keep that value stable once published, because consumers may store it in configuration.
+* `name()` is the human-readable label and does not need to be unique or stable.
+
+For compatibility, rules implemented before `id()` was added inherit an implementation that returns `name()`. `Issue.asString()` and `Issue.toString()` continue to use `name()`, so adding a distinct ID does not change existing text output.
+
 ## Development
 
 ### Building

--- a/js/src/main/scala/io/github/apexdevtools/api/Rule.scala
+++ b/js/src/main/scala/io/github/apexdevtools/api/Rule.scala
@@ -16,7 +16,14 @@ package io.github.apexdevtools.api
 
 /* WARNING: This must be identical to Java class of same name */
 trait Rule {
-  /* The nane of the rule */
+  /*
+   * Stable machine-readable identifier for the rule. New rules should override this with a
+   * lowercase kebab-case value that remains stable across releases. The default preserves
+   * compatibility with existing implementations by using their name as their identifier.
+   */
+  def id(): String = name()
+
+  /* Human-readable name of the rule. It does not need to be unique. */
   def name(): String
 
   /* Range 1-5, 1 being the highest */

--- a/js/src/test/scala/io/github/apexdevtools/api/RuleTest.scala
+++ b/js/src/test/scala/io/github/apexdevtools/api/RuleTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Kevin Jones. All rights reserved.
+ */
+package io.github.apexdevtools.api
+
+import org.scalatest.funspec.AnyFunSpec
+
+class RuleTest extends AnyFunSpec {
+
+  it("uses name as the ID for a legacy Scala.js Rule implementation") {
+    val rule = new Rule {
+      override def name(): String      = "Human-readable name"
+      override def priority(): Integer = Rule.MAJOR_PRIORITY
+    }
+
+    assert(rule.id() == "Human-readable name")
+  }
+
+  it("allows a stable ID to differ from the human-readable name") {
+    val rule = new Rule {
+      override def id(): String        = "missing-type"
+      override def name(): String      = "Missing Type"
+      override def priority(): Integer = Rule.MAJOR_PRIORITY
+    }
+
+    assert(rule.id() == "missing-type")
+    assert(rule.name() == "Missing Type")
+  }
+
+  it("keeps Issue string output based on the human-readable name") {
+    val issue = new TestIssue
+
+    assert(issue.asString == "Missing Type: line 2 at 3-4: Unknown type 'Example'")
+    assert(issue.toString == "Example.cls: Missing Type: line 2 at 3-4: Unknown type 'Example'")
+  }
+
+  private class TestIssue extends Issue {
+    override def provider(): String = "test"
+    override def filePath(): String = "Example.cls"
+    override def fileLocation(): IssueLocation = new IssueLocation {
+      override def startLineNumber(): Int = 2
+      override def startCharOffset(): Int = 3
+      override def endLineNumber(): Int   = 2
+      override def endCharOffset(): Int   = 4
+    }
+    override def rule(): Rule = new Rule {
+      override def id(): String        = "missing-type"
+      override def name(): String      = "Missing Type"
+      override def priority(): Integer = Rule.MAJOR_PRIORITY
+    }
+    override def isError: java.lang.Boolean = true
+    override def message(): String          = "Unknown type 'Example'"
+  }
+}

--- a/jvm/src/main/java/io/github/apexdevtools/api/Rule.java
+++ b/jvm/src/main/java/io/github/apexdevtools/api/Rule.java
@@ -44,7 +44,18 @@ public interface Rule {
     Integer INFO_PRIORITY = 5;
 
     /**
-     * The nane of the rule, does need to be unique but recommended it is
+     * Stable machine-readable identifier for the rule.
+     *
+     * <p>New rules should override this method with a lowercase kebab-case value that remains
+     * stable across releases. The default preserves compatibility with existing implementations;
+     * their name is also used as their identifier.</p>
+     */
+    default String id() {
+        return name();
+    }
+
+    /**
+     * Human-readable name of the rule. It does not need to be unique.
      */
     String name();
 

--- a/jvm/src/test/java/io/github/apexdevtools/api/LegacyJavaRule.java
+++ b/jvm/src/test/java/io/github/apexdevtools/api/LegacyJavaRule.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Kevin Jones. All rights reserved.
+ */
+package io.github.apexdevtools.api;
+
+/** A Rule implementation written against the API shape from before Rule.id() was added. */
+public final class LegacyJavaRule implements Rule {
+    @Override
+    public String name() {
+        return "Human-readable name";
+    }
+
+    @Override
+    public Integer priority() {
+        return MAJOR_PRIORITY;
+    }
+}

--- a/jvm/src/test/scala/io/github/apexdevtools/api/RuleTest.scala
+++ b/jvm/src/test/scala/io/github/apexdevtools/api/RuleTest.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Kevin Jones. All rights reserved.
+ */
+package io.github.apexdevtools.api
+
+import org.scalatest.funspec.AnyFunSpec
+
+class RuleTest extends AnyFunSpec {
+
+  it("publishes id as a Java default method") {
+    assert(classOf[Rule].getMethod("id").isDefault)
+  }
+
+  it("uses name as the ID for a legacy Java Rule implementation") {
+    val rule = new LegacyJavaRule()
+
+    assert(rule.id() == "Human-readable name")
+  }
+
+  it("allows a stable ID to differ from the human-readable name") {
+    val rule = new Rule {
+      override def id(): String        = "missing-type"
+      override def name(): String      = "Missing Type"
+      override def priority(): Integer = Rule.MAJOR_PRIORITY
+    }
+
+    assert(rule.id() == "missing-type")
+    assert(rule.name() == "Missing Type")
+  }
+
+  it("keeps Issue string output based on the human-readable name") {
+    val issue = new TestIssue
+
+    assert(issue.asString() == "Missing Type: line 2 at 3-4: Unknown type 'Example'")
+    assert(issue.toString == "Example.cls: Missing Type: line 2 at 3-4: Unknown type 'Example'")
+  }
+
+  private class TestIssue extends Issue {
+    override def provider(): String = "test"
+    override def filePath(): String = "Example.cls"
+    override def fileLocation(): IssueLocation = new IssueLocation {
+      override def startLineNumber(): Int = 2
+      override def startCharOffset(): Int = 3
+      override def endLineNumber(): Int   = 2
+      override def endCharOffset(): Int   = 4
+    }
+    override def rule(): Rule = new Rule {
+      override def id(): String        = "missing-type"
+      override def name(): String      = "Missing Type"
+      override def priority(): Integer = Rule.MAJOR_PRIORITY
+    }
+    override def isError(): java.lang.Boolean = true
+    override def message(): String            = "Unknown type 'Example'"
+  }
+}


### PR DESCRIPTION
## Summary

- add `Rule.id()` to the published JVM and Scala.js APIs
- default legacy implementations to `name()` while allowing new rules to provide stable lowercase kebab-case IDs
- keep `name()` as the human-readable label and preserve existing `Issue.asString()` / `Issue.toString()` output
- document the API contract and changelog entry

## Compatibility

The JVM method is a Java `default` method, preserving source and binary compatibility for existing external `Rule` implementors. The Scala.js trait provides the same concrete fallback. Tests include a legacy Java implementation that does not define `id()` and an assertion that the JVM method is published as a default method.

## Tests

- `sbt scalafmtCheck`
- `sbt build`
- `sbt test` with the pinned `apex-samples` v1.4.0 corpus
- focused JVM and Scala.js `RuleTest` suites

## Downstream steps

After this PR merges, publish a new `outline-parser` release. Then apex-dev-tools/apex-ls#322 can bump the released `outline-parser` version in `build.sbt` and assign stable IDs to its diagnostics. This PR does not publish a release or modify `apex-ls`.

Closes #35
