### PR TITLE
feat: expose located, structured annotation parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Added `Rule.id()` as a stable machine-readable rule identifier on JVM and Scala.js. Existing implementations remain compatible and default to `name()`; new rules should override it with a stable lowercase kebab-case ID. Existing `Issue` string output remains unchanged.
 
+- Added `Annotation.parameterList`, a located, structured view of an annotation's parameter list, alongside the existing unparsed `parameters` string.
+  - Each `AnnotationParameter` carries its name (where one was written), its value, the separator written before it, and locations for the name, the value and the parameter as a whole.
+  - The separator is recorded as `AnnotationParameterSeparator.Whitespace` or `AnnotationParameterSeparator.Comma`. Apex only accepts whitespace, but a comma is retained rather than rejected so that consumers can diagnose it.
+  - Nothing is validated here. Names and values are left uninterpreted and forms Apex does not accept still parse.
+  - `parameters` is unchanged, as are `Annotation` equality and hashing. Neither `location` nor `parameterList` takes part in them.
+
 ## 2.0.0 - 2026-07-03
 
 ### General

--- a/shared/src/main/scala/io/github/apexdevtools/oparser/Types.scala
+++ b/shared/src/main/scala/io/github/apexdevtools/oparser/Types.scala
@@ -6,6 +6,8 @@ package io.github.apexdevtools.oparser
 import io.github.apexdevtools.types.{base, _}
 import io.github.apexdevtools.types.base.{
   Annotation,
+  AnnotationParameter,
+  AnnotationParameterSeparator,
   IdLocationHolder,
   IdWithLocation,
   Location,
@@ -657,8 +659,12 @@ object Parse {
     }
     val qName = QualifiedName(names.toArray)
 
-    val parameters = if (tokens(index).exists(_.matches(Tokens.LParenStr))) {
-      val builder      = new mutable.StringBuilder()
+    // Collect the tokens between the annotation's parentheses, recording the nesting depth of
+    // each so that a nested list can be told apart from the parameter list itself.
+    val builder       = new mutable.StringBuilder()
+    val contained     = new ArrayBuffer[(Token, Int)]()
+    val hasParameters = tokens(index).exists(_.matches(Tokens.LParenStr))
+    if (hasParameters) {
       var nestingCount = 1
       index += 1
       while (nestingCount > 0 && index < tokens.length) {
@@ -667,19 +673,111 @@ object Parse {
         } else if (tokens.get(index).matches(Tokens.LParenStr)) {
           nestingCount += 1
         }
-        if (nestingCount > 0) builder.append(tokens.get(index).contents)
+        if (nestingCount > 0) {
+          builder.append(tokens.get(index).contents)
+          contained.append((tokens.get(index), nestingCount))
+        }
         index += 1
       }
-      Some(builder.toString())
-    } else None
+    }
+    val parameters    = if (hasParameters) Some(builder.toString()) else None
+    val parameterList = if (hasParameters) Some(splitAnnotationParameters(contained)) else None
 
     // Capture full annotation location from @ through parameters
     val endLocation  = if (index > 0) tokens.get(index - 1).location else startLocation
     val fullLocation = Location.span(startLocation, endLocation)
 
-    accum.append(Annotation(qName.toString, parameters, Some(fullLocation)))
+    accum.append(Annotation(qName.toString, parameters, Some(fullLocation), parameterList))
 
     index
+  }
+
+  /* Nesting depth of the annotation's own parameter list, anything deeper is a nested list. */
+  private val topLevelParameterDepth = 1
+
+  /** Split the tokens of an annotation's parameter list into located parameters.
+    *
+    * This does not validate, its job is to record what was written and where. Parameters are
+    * separated either by a comma, which Apex does not accept but which must still be representable,
+    * or by whitespace, recognised as a gap in the source before an identifier that is followed by
+    * '='. Anything that fits neither shape is left as a single parameter rather than being
+    * rejected.
+    */
+  private def splitAnnotationParameters(
+    contained: ArrayBuffer[(Token, Int)]
+  ): ArraySeq[AnnotationParameter] = {
+    if (contained.isEmpty) return AnnotationParameter.emptyArraySeq
+
+    val parameters = new ArrayBuffer[AnnotationParameter]()
+    val current    = new ArrayBuffer[Token]()
+    var separator  = Option.empty[AnnotationParameterSeparator]
+
+    def flush(): Unit = {
+      parameters.append(toAnnotationParameter(current, separator))
+      current.clear()
+    }
+
+    var index = 0
+    while (index < contained.length) {
+      val (token, depth) = contained(index)
+      if (depth == topLevelParameterDepth && token.contents == Tokens.CommaStr) {
+        flush()
+        separator = Some(AnnotationParameterSeparator.Comma)
+      } else if (
+        depth == topLevelParameterDepth && current.nonEmpty &&
+        startsAnnotationParameter(contained, index)
+      ) {
+        flush()
+        separator = Some(AnnotationParameterSeparator.Whitespace)
+        current.append(token)
+      } else {
+        current.append(token)
+      }
+      index += 1
+    }
+    flush()
+
+    ArraySeq.unsafeWrapArray(parameters.toArray)
+  }
+
+  /* A parameter starts here if the source has whitespace before an identifier that is being
+   * assigned to, which is the only way Apex separates one parameter from the next. */
+  private def startsAnnotationParameter(
+    contained: ArrayBuffer[(Token, Int)],
+    index: Int
+  ): Boolean = {
+    val token = contained(index)._1
+    token.isInstanceOf[LocatableIdToken] &&
+    index > 0 &&
+    contained(index - 1)._1.location.endByteOffset < token.location.startByteOffset &&
+    index + 1 < contained.length && {
+      val (next, depth) = contained(index + 1)
+      depth == topLevelParameterDepth && next.contents == Tokens.EqualsStr
+    }
+  }
+
+  private def toAnnotationParameter(
+    tokens: ArrayBuffer[Token],
+    separator: Option[AnnotationParameterSeparator]
+  ): AnnotationParameter = {
+    if (tokens.isEmpty) return AnnotationParameter(None, "", separator)
+
+    val isNamed = tokens.length > 1 &&
+      tokens.head.isInstanceOf[LocatableIdToken] &&
+      tokens(1).contents == Tokens.EqualsStr
+
+    val name         = if (isNamed) Some(tokens.head.contents) else None
+    val nameLocation = if (isNamed) Some(tokens.head.location) else None
+    val valueTokens  = if (isNamed) tokens.drop(2) else tokens
+
+    AnnotationParameter(
+      name,
+      valueTokens.map(_.contents).mkString,
+      separator,
+      nameLocation,
+      valueTokens.headOption.map(head => Location.span(head.location, valueTokens.last.location)),
+      Some(Location.span(tokens.head.location, tokens.last.location))
+    )
   }
 
   private val modifierTokenStrs = Set(

--- a/shared/src/main/scala/io/github/apexdevtools/types/base/Annotation.scala
+++ b/shared/src/main/scala/io/github/apexdevtools/types/base/Annotation.scala
@@ -3,20 +3,37 @@
  */
 package io.github.apexdevtools.types.base
 
+import scala.collection.immutable.ArraySeq
 import scala.util.hashing.MurmurHash3
 
-/** Annotation element, name is case-insensitive, parameters are unparsed. */
-case class Annotation(name: String, parameters: Option[String], location: Option[Location] = None) {
+/** Annotation element, name is case-insensitive.
+  *
+  * Parameters are available in two forms. `parameters` is the original unparsed string, a
+  * concatenation of the token contents between the parentheses, empty when the annotation was
+  * written without them. `parameterList` is the same content split into located parameters, see
+  * [[AnnotationParameter]]; it is empty when the annotation was written without parentheses and an
+  * empty sequence when they were written but hold nothing.
+  */
+case class Annotation(
+  name: String,
+  parameters: Option[String],
+  location: Option[Location] = None,
+  parameterList: Option[ArraySeq[AnnotationParameter]] = None
+) {
   override def equals(obj: Any): Boolean = {
     val other = obj.asInstanceOf[Annotation]
     name.equalsIgnoreCase(other.name) &&
     parameters.getOrElse("").equalsIgnoreCase(other.parameters.getOrElse(""))
-    // Note: location intentionally excluded from equality
+    // Note: location & parameterList intentionally excluded from equality. Equality is over the
+    // annotation as written, and annotations are compared across producers that populate only
+    // 'parameters', so including parameterList would change set/map behaviour for existing
+    // consumers. It would also be finer than 'parameters' alone, e.g. 'a=1 b=2' and 'a=1b=2' share
+    // a parameters string but not a parameterList.
   }
 
   override def hashCode(): Int = {
     MurmurHash3.orderedHash(Seq(name.toLowerCase(), parameters.getOrElse("")))
-    // Note: location intentionally excluded from hash
+    // Note: location & parameterList intentionally excluded from hash
   }
 
   override def toString: String = {

--- a/shared/src/main/scala/io/github/apexdevtools/types/base/AnnotationParameter.scala
+++ b/shared/src/main/scala/io/github/apexdevtools/types/base/AnnotationParameter.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Kevin Jones. All rights reserved.
+ */
+package io.github.apexdevtools.types.base
+
+import scala.collection.immutable.ArraySeq
+
+/** Separator written between two annotation parameters.
+  *
+  * Apex only accepts whitespace here; the platform compiler rejects a comma. Both forms are
+  * recorded so that a consumer can diagnose the illegal one, the parser does not reject it.
+  */
+sealed abstract class AnnotationParameterSeparator(val text: String) {
+  override def toString: String = text
+}
+
+object AnnotationParameterSeparator {
+
+  /** Whitespace, the only separator the platform compiler accepts. */
+  case object Whitespace extends AnnotationParameterSeparator(" ")
+
+  /** A comma, which the platform compiler rejects. */
+  case object Comma extends AnnotationParameterSeparator(",")
+}
+
+/** A single parameter of an annotation, as it was written.
+  *
+  * `name` is set only for the `name = value` form, it is empty for a bare value such as the
+  * argument of `@SuppressWarnings('PMD')`. Values are left uninterpreted, quotes and all, no
+  * attempt is made to establish whether the name or value is legal for the annotation.
+  *
+  * As with the unparsed `Annotation.parameters` string, the text of a value is a concatenation of
+  * token contents so any whitespace inside it is not preserved. Use `valueLocation` against the
+  * source if the exact text matters.
+  *
+  * `precedingSeparator` is the separator written between this parameter and the one before it, it
+  * is empty for the first parameter of a list.
+  */
+final case class AnnotationParameter(
+  name: Option[String],
+  value: String,
+  precedingSeparator: Option[AnnotationParameterSeparator] = None,
+  nameLocation: Option[Location] = None,
+  valueLocation: Option[Location] = None,
+  location: Option[Location] = None
+) {
+  override def toString: String = name.map(n => s"$n=$value").getOrElse(value)
+}
+
+object AnnotationParameter {
+  final val emptyArraySeq: ArraySeq[AnnotationParameter] = ArraySeq()
+}

--- a/shared/src/test/scala/io/github/apexdevtools/oparser/AnnotationParameterTest.scala
+++ b/shared/src/test/scala/io/github/apexdevtools/oparser/AnnotationParameterTest.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026 Kevin Jones. All rights reserved.
+ */
+package io.github.apexdevtools.oparser
+
+import io.github.apexdevtools.types.base.AnnotationParameterSeparator.{Comma, Whitespace}
+import io.github.apexdevtools.types.base.{Annotation, AnnotationParameter, Location}
+import org.scalatest.funspec.AnyFunSpec
+
+import java.nio.charset.StandardCharsets
+
+class AnnotationParameterTest extends AnyFunSpec {
+
+  private var source: String = ""
+
+  /* Parse an annotation written on a class, retaining the source for location checks. */
+  def annotation(text: String): Annotation = {
+    source = s"$text\npublic class Dummy {\n}\n"
+    val (_, ex, td) = OutlineParser.parse("Dummy.cls", source, TestClassFactory, ctx = null)
+    ex.foreach(ex => throw new Exception(ex))
+    val annotations = td.get.annotations
+    assert(annotations.length == 1)
+    annotations.head
+  }
+
+  def parameters(text: String): Seq[AnnotationParameter] =
+    annotation(text).parameterList.getOrElse(fail("no parameter list"))
+
+  def extract(location: Option[Location]): String = {
+    val bytes = source.getBytes(StandardCharsets.UTF_8)
+    location
+      .map(l => new String(bytes.slice(l.startByteOffset, l.endByteOffset), StandardCharsets.UTF_8))
+      .getOrElse("<none>")
+  }
+
+  describe("presence of a parameter list") {
+    it("has none when written without parentheses") {
+      val a = annotation("@AuraEnabled")
+      assert(a.parameters.isEmpty)
+      assert(a.parameterList.isEmpty)
+    }
+
+    it("has an empty one when written with empty parentheses") {
+      val a = annotation("@AuraEnabled()")
+      assert(a.parameters.contains(""))
+      assert(a.parameterList.exists(_.isEmpty))
+    }
+  }
+
+  describe("parameter forms") {
+    it("reads a single unnamed value") {
+      val params = parameters("@SuppressWarnings('PMD')")
+      assert(params.length == 1)
+      assert(params.head.name.isEmpty)
+      assert(params.head.value == "'PMD'")
+      assert(params.head.precedingSeparator.isEmpty)
+    }
+
+    it("reads a named value") {
+      val params = parameters("@AuraEnabled(cacheable=true)")
+      assert(params.length == 1)
+      assert(params.head.name.contains("cacheable"))
+      assert(params.head.value == "true")
+    }
+
+    it("keeps a named value when spaced around the assignment") {
+      val params = parameters("@AuraEnabled( cacheable = true )")
+      assert(params.length == 1)
+      assert(params.head.name.contains("cacheable"))
+      assert(params.head.value == "true")
+    }
+
+    it("keeps separators inside a quoted value") {
+      val params = parameters("@SuppressWarnings('PMD,Unused')")
+      assert(params.length == 1)
+      assert(params.head.name.isEmpty)
+      assert(params.head.value == "'PMD,Unused'")
+    }
+
+    it("keeps whitespace inside a quoted value") {
+      val params = parameters("@InvocableMethod(label='a b' description='c')")
+      assert(params.map(_.value) == Seq("'a b'", "'c'"))
+      assert(params.map(_.name) == Seq(Some("label"), Some("description")))
+    }
+  }
+
+  describe("separators") {
+    it("records whitespace between parameters") {
+      val params = parameters("@AuraEnabled(cacheable=true scope='global')")
+      assert(params.map(_.name) == Seq(Some("cacheable"), Some("scope")))
+      assert(params.map(_.value) == Seq("true", "'global'"))
+      assert(params.map(_.precedingSeparator) == Seq(None, Some(Whitespace)))
+    }
+
+    it("records a comma between parameters, it is not legal Apex but must be visible") {
+      val params = parameters("@AuraEnabled(cacheable=true, scope='global')")
+      assert(params.map(_.name) == Seq(Some("cacheable"), Some("scope")))
+      assert(params.map(_.value) == Seq("true", "'global'"))
+      assert(params.map(_.precedingSeparator) == Seq(None, Some(Comma)))
+    }
+
+    it("records a comma written without surrounding space") {
+      val params = parameters("@AuraEnabled(cacheable=true,scope='global')")
+      assert(params.map(_.precedingSeparator) == Seq(None, Some(Comma)))
+    }
+
+    it("records a trailing comma as an empty parameter") {
+      val params = parameters("@AuraEnabled(cacheable=true,)")
+      assert(params.length == 2)
+      assert(params(1).name.isEmpty)
+      assert(params(1).value.isEmpty)
+      assert(params(1).precedingSeparator.contains(Comma))
+    }
+
+    it("separates across a newline") {
+      val params = parameters("@AuraEnabled(cacheable=true\n    scope='global')")
+      assert(params.map(_.name) == Seq(Some("cacheable"), Some("scope")))
+      assert(params.map(_.precedingSeparator) == Seq(None, Some(Whitespace)))
+    }
+
+    it("does not separate where no separator was written") {
+      // Not legal Apex, but the parser records what is there rather than rejecting it
+      val params = parameters("@AuraEnabled(cacheable=truescope='global')")
+      assert(params.length == 1)
+      assert(params.head.name.contains("cacheable"))
+      assert(params.head.value == "truescope='global'")
+    }
+
+    it("mixes separators") {
+      val params = parameters("@InvocableMethod(label='x', description='y' category='z')")
+      assert(params.map(_.name) == Seq(Some("label"), Some("description"), Some("category")))
+      assert(params.map(_.precedingSeparator) == Seq(None, Some(Comma), Some(Whitespace)))
+    }
+  }
+
+  describe("nesting") {
+    it("does not separate on a comma inside nested parentheses") {
+      val params = parameters("@Dummy(a=f(1, 2) b=3)")
+      assert(params.length == 2)
+      assert(params.map(_.name) == Seq(Some("a"), Some("b")))
+      assert(params.map(_.value) == Seq("f(1,2)", "3"))
+      assert(params.map(_.precedingSeparator) == Seq(None, Some(Whitespace)))
+    }
+
+    it("does not start a parameter inside nested parentheses") {
+      val params = parameters("@Dummy(a=f(b=1) c=2)")
+      assert(params.map(_.name) == Seq(Some("a"), Some("c")))
+      assert(params.map(_.value) == Seq("f(b=1)", "2"))
+    }
+  }
+
+  describe("locations") {
+    it("anchors the name, the value and the whole parameter") {
+      val params = parameters("@AuraEnabled(cacheable=true scope='global')")
+      assert(params.map(p => extract(p.nameLocation)) == Seq("cacheable", "scope"))
+      assert(params.map(p => extract(p.valueLocation)) == Seq("true", "'global'"))
+      assert(params.map(p => extract(p.location)) == Seq("cacheable=true", "scope='global'"))
+    }
+
+    it("anchors an unnamed value") {
+      val params = parameters("@SuppressWarnings('PMD')")
+      assert(extract(params.head.nameLocation) == "<none>")
+      assert(extract(params.head.valueLocation) == "'PMD'")
+      assert(extract(params.head.location) == "'PMD'")
+    }
+
+    it("has no value location for a name with nothing assigned") {
+      val params = parameters("@Dummy(a= )")
+      assert(params.length == 1)
+      assert(params.head.name.contains("a"))
+      assert(params.head.value.isEmpty)
+      assert(params.head.valueLocation.isEmpty)
+      assert(extract(params.head.location) == "a=")
+    }
+  }
+
+  describe("the unparsed parameters string") {
+    it("is unchanged for each form") {
+      assert(annotation("@AuraEnabled").parameters.isEmpty)
+      assert(annotation("@AuraEnabled()").parameters.contains(""))
+      assert(annotation("@SuppressWarnings('PMD')").parameters.contains("'PMD'"))
+      assert(
+        annotation("@AuraEnabled(cacheable=true scope='global')").parameters
+          .contains("cacheable=truescope='global'")
+      )
+      assert(
+        annotation("@AuraEnabled(cacheable=true, scope='global')").parameters
+          .contains("cacheable=true,scope='global'")
+      )
+      assert(annotation("@Dummy(a=f(1, 2) b=3)").parameters.contains("a=f(1,2)b=3"))
+    }
+  }
+
+  describe("equality") {
+    it("ignores the parameter list, as it does the location") {
+      val spaced = annotation("@AuraEnabled(cacheable=true scope='global')")
+      val hand   = Annotation(spaced.name, spaced.parameters)
+      assert(hand.parameterList.isEmpty)
+      assert(spaced == hand)
+      assert(spaced.hashCode() == hand.hashCode())
+    }
+  }
+}


### PR DESCRIPTION
Closes #37.

Annotation parameters were only reachable as `Annotation.parameters`, a single unparsed string built
by concatenating token contents. Token contents exclude whitespace, so the space separator — the only
one Apex accepts — was destroyed, and there was nothing to anchor a per-parameter diagnostic on.

This adds `Annotation.parameterList` alongside that string. The tokens were already located, so no
new lexing was needed; the same token run that builds `parameters` is now also structured.

## What was added

```scala
case class Annotation(
  name: String,
  parameters: Option[String],
  location: Option[Location] = None,
  parameterList: Option[ArraySeq[AnnotationParameter]] = None   // new
)

final case class AnnotationParameter(
  name: Option[String],
  value: String,
  precedingSeparator: Option[AnnotationParameterSeparator] = None,
  nameLocation: Option[Location] = None,
  valueLocation: Option[Location] = None,
  location: Option[Location] = None
)

sealed abstract class AnnotationParameterSeparator(val text: String)
object AnnotationParameterSeparator {
  case object Whitespace extends AnnotationParameterSeparator(" ")
  case object Comma      extends AnnotationParameterSeparator(",")
}
```

`parameterList` mirrors `parameters` in shape: `None` when the annotation was written without
parentheses, `Some(empty)` when they were written but hold nothing. The separator is recorded on the
parameter that follows it, so the first parameter of a list has none.

| Written | `parameters` (unchanged) | `parameterList` |
|---|---|---|
| `@AuraEnabled` | `None` | `None` |
| `@AuraEnabled()` | `Some("")` | `Some([])` |
| `@SuppressWarnings('PMD')` | `Some("'PMD'")` | one unnamed, value `'PMD'` |
| `@AuraEnabled(cacheable=true scope='global')` | `Some("cacheable=truescope='global'")` | `cacheable`=`true`, then `scope`=`'global'` preceded by `Whitespace` |
| `@AuraEnabled(cacheable=true, scope='global')` | `Some("cacheable=true,scope='global'")` | same two, second preceded by `Comma` |

## Nothing is validated

Values are left uninterpreted, quotes and all. The comma form — which the platform compiler rejects,
see apex-dev-tools/apex-ls#326 — parses and is represented as `Comma`, so apex-ls can diagnose it
rather than the file failing to parse. Same for a trailing comma, which becomes an empty trailing
parameter, and for a name with nothing assigned to it.

How a parameter boundary is found, given whitespace is not tokenised: a comma at the parameter list's
own nesting depth always separates, and otherwise a new parameter starts at an identifier that has a
gap before it in the source and an `=` after it. Anything fitting neither shape stays a single
parameter instead of being rejected — so `@AuraEnabled(cacheable=truescope='global')`, with no
separator at all, is one parameter named `cacheable` with value `truescope='global'`, which is both
faithful to the source and diagnosable.

Two limits worth stating, both pre-existing tokeniser behaviour rather than anything new here:

- A value's *text* is still a concatenation of token contents, so whitespace inside a value is not
  preserved. `valueLocation` is the way to recover exact text from the source, which is what a
  consumer wanting to quote it should use.
- The tokeniser merges some adjacent punctuation, e.g. `label={'a','b'}` lexes `={` as one token, so
  that array-initialiser form is read as two unnamed parameters separated by a comma. It is not legal
  Apex; it parses and is diagnosable, which is what this change is for.

## Equality: `parameterList` does not participate

Deliberate, and left as-is for `location` too, for three reasons:

1. Annotations are compared across producers. The test suite's ANTLR reference parser populates only
   `parameters` — including `parameterList` would break every one of the 6,262 sample comparisons.
2. Including it would silently change set/map behaviour for existing consumers, which #37 explicitly
   warned about.
3. It would be *finer* than `parameters` alone rather than redundant: `a=1 b=2` and `a=1b=2` share a
   `parameters` string but not a `parameterList`. Making equality finer without warning is the change
   most likely to surprise.

The rationale is recorded in the code next to `equals`/`hashCode`, and there is a test asserting a
hand-built `Annotation` with no `parameterList` still equals a parsed one.

## Compatibility

`parameters` is byte-identical — it is still built by the same `StringBuilder` over the same tokens,
and there is a test pinning its output for each form. Source compatibility is kept by giving the new
field a default. Note that adding a field to a case class is **binary** breaking, so consumers must
recompile; that is already the plan here, since apex-ls picks this up via a release and a `build.sbt`
bump.

## Tests

`AnnotationParameterTest` (shared, so it runs on both platforms) covers 21 cases: the separator forms
including none at all and across a newline, quoted values containing separators
(`@SuppressWarnings('PMD,Unused')`), quoted values containing spaces, nested parentheses with a comma
inside them, the empty list, no list at all, a trailing comma, a name with no value, location
anchoring for name/value/whole parameter, the `parameters` string for every form, and equality.

Run on JDK 17:

- `sbt scalafmtCheck` — pass
- `sbt build` — pass (JVM jar and Scala.js full opt)
- `sbt parserJVM/test` — 6339 passed, 0 failed, including 6,262 ANTLR comparisons over `apex-samples`
  at `v1.4.0` with `SAMPLES` set
- `sbt parserJS/test` — 76 passed, 0 failed

## Risks / follow-ups

- Behaviour risk is low: the only change to existing output is the added field. The sample corpus
  comparison is the evidence for that.
- Next in the sequence is a release, then the `outline-parser` bump in `apex-ls/build.sbt` and the
  consumption work in apex-ls#326. Neither is touched here.
