### PR TITLE
feat!: replace the unparsed annotation parameter string with a structured, located one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,17 @@
 
 - Added `Rule.id()` as a stable machine-readable rule identifier on JVM and Scala.js. Existing implementations remain compatible and default to `name()`; new rules should override it with a stable lowercase kebab-case ID. Existing `Issue` string output remains unchanged.
 
-- Added `Annotation.parameterList`, a located, structured view of an annotation's parameter list, replacing the unparsed `parameters` string as the way to read parameters.
+- **(BREAKING)** `Annotation.parameters`, the unparsed parameter string, is removed and replaced by `Annotation.parameterList`, a located, structured view of the parameter list.
   - Each `AnnotationParameter` carries its name (where one was written), its value, the separator written before it, and locations for the name, the value and the parameter as a whole.
   - The separator is recorded as `AnnotationParameterSeparator.Whitespace` or `AnnotationParameterSeparator.Comma`. Apex only accepts whitespace, but a comma is retained rather than rejected so that consumers can diagnose it.
+  - `parameterList` is empty when the annotation was written without parentheses and an empty sequence when they were written but hold nothing, matching what `parameters` distinguished with `None` and `Some("")`.
   - Nothing is validated here. Names and values are left uninterpreted and forms Apex does not accept still parse.
+  - `parameters` was a concatenation of token contents, so it could not represent the separator between two parameters. It is removed rather than deprecated so that no published version presents it as the way to read parameters.
 
-- **(BREAKING)** `Annotation.parameters` is deprecated, and `Annotation` equality and hashing now take `parameterList` into account.
-  - `parameters` remains populated and keeps its current content, but it is a concatenation of token contents and cannot represent the separator between two parameters. Read `parameterList` instead.
-  - Equality was previously over `name` and `parameters` alone. It is now also over `parameterList`, so two annotations whose lossy strings coincide but whose structure differs — `@Dummy(a=1 b=2)` and `@Dummy(a=1b=2)` both give `a=1b=2` — are no longer equal. `location` is still excluded, and `AnnotationParameter` excludes its own locations for the same reason.
-  - An `Annotation` built by hand with only `parameters` no longer equals a parsed one, since its `parameterList` is empty.
-  - Fixed `Annotation.hashCode` not lowering the parameters string. `equals` has always compared it case-insensitively, so annotations differing only in case were equal but hashed differently.
-  - `AnnotationParameter` compares names and values case-insensitively, matching how the platform treats them and how `parameters` was already compared.
+- **(BREAKING)** `Annotation` equality, hashing and rendering are now over `parameterList`.
+  - Equality is over the name and the parameters in the order and form they were written, so two annotations whose flattened text coincides but whose structure differs — `@Dummy(a=1 b=2)` and `@Dummy(a=1b=2)` — are no longer equal, and neither are lists that differ only in their separator. `location` is still excluded, as it is on `Modifier`, and `AnnotationParameter` excludes its own locations for the same reason.
+  - `AnnotationParameter` compares names and values case-insensitively, as the platform treats them and as `parameters` was already compared.
+  - `toString` is rebuilt from `parameterList` and now renders the separator that was written, so `@AuraEnabled(cacheable=true scope='global')` renders as written rather than as the whitespace-stripped `@AuraEnabled(cacheable=truescope='global')`. Whitespace is normalised to a single space, so the rendering is faithful but not verbatim. This also changes `IBodyDeclaration` output, which includes annotations.
 
 ### Build & dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,21 @@
 
 - Added `Rule.id()` as a stable machine-readable rule identifier on JVM and Scala.js. Existing implementations remain compatible and default to `name()`; new rules should override it with a stable lowercase kebab-case ID. Existing `Issue` string output remains unchanged.
 
-- Added `Annotation.parameterList`, a located, structured view of an annotation's parameter list, alongside the existing unparsed `parameters` string.
+- Added `Annotation.parameterList`, a located, structured view of an annotation's parameter list, replacing the unparsed `parameters` string as the way to read parameters.
   - Each `AnnotationParameter` carries its name (where one was written), its value, the separator written before it, and locations for the name, the value and the parameter as a whole.
   - The separator is recorded as `AnnotationParameterSeparator.Whitespace` or `AnnotationParameterSeparator.Comma`. Apex only accepts whitespace, but a comma is retained rather than rejected so that consumers can diagnose it.
   - Nothing is validated here. Names and values are left uninterpreted and forms Apex does not accept still parse.
-  - `parameters` is unchanged, as are `Annotation` equality and hashing. Neither `location` nor `parameterList` takes part in them.
+
+- **(BREAKING)** `Annotation.parameters` is deprecated, and `Annotation` equality and hashing now take `parameterList` into account.
+  - `parameters` remains populated and keeps its current content, but it is a concatenation of token contents and cannot represent the separator between two parameters. Read `parameterList` instead.
+  - Equality was previously over `name` and `parameters` alone. It is now also over `parameterList`, so two annotations whose lossy strings coincide but whose structure differs — `@Dummy(a=1 b=2)` and `@Dummy(a=1b=2)` both give `a=1b=2` — are no longer equal. `location` is still excluded, and `AnnotationParameter` excludes its own locations for the same reason.
+  - An `Annotation` built by hand with only `parameters` no longer equals a parsed one, since its `parameterList` is empty.
+  - Fixed `Annotation.hashCode` not lowering the parameters string. `equals` has always compared it case-insensitively, so annotations differing only in case were equal but hashed differently.
+  - `AnnotationParameter` compares names and values case-insensitively, matching how the platform treats them and how `parameters` was already compared.
+
+### Build & dependencies
+
+- Updated the `apex-parser` test dependency to 5.2.0, which tightens the annotation grammar. The ANTLR reference parser used by the sample comparison now builds a full `parameterList`, so the structured form is compared against a second parser across the sample corpus rather than only being produced.
 
 ## 2.0.0 - 2026-07-03
 

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val parser = crossProject(JSPlatform, JVMPlatform)
     build       := buildJVM.value,
     Test / fork := true,
     libraryDependencies ++= Seq(
-      "io.github.apex-dev-tools" % "apex-parser"                % "5.1.0" % Test,
+      "io.github.apex-dev-tools" % "apex-parser"                % "5.2.0" % Test,
       "org.scala-lang.modules"  %% "scala-parallel-collections" % "1.0.4" % Test
     ),
     packageOptions += Package.ManifestAttributes(

--- a/jvm/src/test/scala/io/github/apexdevtools/oparser/testutil/AntlrParser.scala
+++ b/jvm/src/test/scala/io/github/apexdevtools/oparser/testutil/AntlrParser.scala
@@ -84,12 +84,72 @@ object AntlrParser {
   }
 
   def antlrAnnotation(ctx: ApexParser.AnnotationContext): Annotation = {
-    val qName = QualifiedName(ctx.qualifiedName().id().asScala.map(id => toId(id)).toArray)
-    val args = Option(ctx.elementValue())
-      .map(_.getText)
-      .orElse(Option(ctx.elementValuePairs()).map(_.getText))
-      .orElse(if (ctx.getText.endsWith("()")) Some("") else None)
-    Annotation(qName.toString, args, Some(ctx.location))
+    val hasParameters = ctx.LPAREN() != null
+    val parameters =
+      if (hasParameters)
+        Some(
+          Option(ctx.elementValue())
+            .map(_.getText)
+            .orElse(Option(ctx.elementValuePairs()).map(_.getText))
+            .getOrElse("")
+        )
+      else None
+    val parameterList = if (hasParameters) Some(antlrAnnotationParameters(ctx)) else None
+    Annotation(ctx.id().getText, parameters, Some(ctx.location), parameterList)
+  }
+
+  /* Build the same parameter model the outline parser produces, so the two can be compared. A
+   * comma is a token in the tree, its absence between two pairs means they were separated by
+   * whitespace. */
+  private def antlrAnnotationParameters(
+    ctx: ApexParser.AnnotationContext
+  ): ArraySeq[AnnotationParameter] = {
+    Option(ctx.elementValue())
+      .map(value =>
+        ArraySeq(
+          AnnotationParameter(
+            None,
+            value.getText,
+            None,
+            None,
+            Some(value.location),
+            Some(value.location)
+          )
+        )
+      )
+      .orElse(Option(ctx.elementValuePairs()).map(antlrElementValuePairs))
+      .getOrElse(AnnotationParameter.emptyArraySeq)
+  }
+
+  private def antlrElementValuePairs(
+    ctx: ApexParser.ElementValuePairsContext
+  ): ArraySeq[AnnotationParameter] = {
+    val parameters = ArraySeq.newBuilder[AnnotationParameter]
+    var isFirst    = true
+    var sawComma   = false
+
+    ctx.children.asScala.foreach {
+      case pair: ApexParser.ElementValuePairContext =>
+        val separator =
+          if (isFirst) None
+          else if (sawComma) Some(AnnotationParameterSeparator.Comma)
+          else Some(AnnotationParameterSeparator.Whitespace)
+        val value = pair.elementValue()
+        parameters += AnnotationParameter(
+          Some(pair.id().getText),
+          value.getText,
+          separator,
+          Some(pair.id().location),
+          Some(value.location),
+          Some(pair.location)
+        )
+        isFirst = false
+        sawComma = false
+      case node: TerminalNode if node.getSymbol.getType == ApexParser.COMMA =>
+        sawComma = true
+      case _ => ()
+    }
+    parameters.result()
   }
 
   def antlrTypeList(ctx: ApexParser.TypeListContext): ArraySeq[TypeRef] = {

--- a/jvm/src/test/scala/io/github/apexdevtools/oparser/testutil/AntlrParser.scala
+++ b/jvm/src/test/scala/io/github/apexdevtools/oparser/testutil/AntlrParser.scala
@@ -84,18 +84,9 @@ object AntlrParser {
   }
 
   def antlrAnnotation(ctx: ApexParser.AnnotationContext): Annotation = {
-    val hasParameters = ctx.LPAREN() != null
-    val parameters =
-      if (hasParameters)
-        Some(
-          Option(ctx.elementValue())
-            .map(_.getText)
-            .orElse(Option(ctx.elementValuePairs()).map(_.getText))
-            .getOrElse("")
-        )
-      else None
-    val parameterList = if (hasParameters) Some(antlrAnnotationParameters(ctx)) else None
-    Annotation(ctx.id().getText, parameters, Some(ctx.location), parameterList)
+    val parameterList =
+      if (ctx.LPAREN() != null) Some(antlrAnnotationParameters(ctx)) else None
+    Annotation(ctx.id().getText, parameterList, Some(ctx.location))
   }
 
   /* Build the same parameter model the outline parser produces, so the two can be compared. A

--- a/shared/src/main/scala/io/github/apexdevtools/oparser/Types.scala
+++ b/shared/src/main/scala/io/github/apexdevtools/oparser/Types.scala
@@ -661,7 +661,6 @@ object Parse {
 
     // Collect the tokens between the annotation's parentheses, recording the nesting depth of
     // each so that a nested list can be told apart from the parameter list itself.
-    val builder       = new mutable.StringBuilder()
     val contained     = new ArrayBuffer[(Token, Int)]()
     val hasParameters = tokens(index).exists(_.matches(Tokens.LParenStr))
     if (hasParameters) {
@@ -673,21 +672,17 @@ object Parse {
         } else if (tokens.get(index).matches(Tokens.LParenStr)) {
           nestingCount += 1
         }
-        if (nestingCount > 0) {
-          builder.append(tokens.get(index).contents)
-          contained.append((tokens.get(index), nestingCount))
-        }
+        if (nestingCount > 0) contained.append((tokens.get(index), nestingCount))
         index += 1
       }
     }
-    val parameters    = if (hasParameters) Some(builder.toString()) else None
     val parameterList = if (hasParameters) Some(splitAnnotationParameters(contained)) else None
 
     // Capture full annotation location from @ through parameters
     val endLocation  = if (index > 0) tokens.get(index - 1).location else startLocation
     val fullLocation = Location.span(startLocation, endLocation)
 
-    accum.append(Annotation(qName.toString, parameters, Some(fullLocation), parameterList))
+    accum.append(Annotation(qName.toString, parameterList, Some(fullLocation)))
 
     index
   }

--- a/shared/src/main/scala/io/github/apexdevtools/types/base/Annotation.scala
+++ b/shared/src/main/scala/io/github/apexdevtools/types/base/Annotation.scala
@@ -3,19 +3,24 @@
  */
 package io.github.apexdevtools.types.base
 
+import scala.annotation.nowarn
 import scala.collection.immutable.ArraySeq
 import scala.util.hashing.MurmurHash3
 
 /** Annotation element, name is case-insensitive.
   *
-  * Parameters are available in two forms. `parameters` is the original unparsed string, a
-  * concatenation of the token contents between the parentheses, empty when the annotation was
-  * written without them. `parameterList` is the same content split into located parameters, see
-  * [[AnnotationParameter]]; it is empty when the annotation was written without parentheses and an
-  * empty sequence when they were written but hold nothing.
+  * `parameterList` is the parameter list as written, see [[AnnotationParameter]]. It is empty when
+  * the annotation was written without parentheses and an empty sequence when they were written but
+  * hold nothing.
+  *
+  * `parameters` is the same content as a single unparsed string and is deprecated. It is a
+  * concatenation of token contents, so it cannot represent the separator between two parameters,
+  * which is the whole point of reading them.
   */
+@nowarn("cat=deprecation") // this class necessarily still reads its own deprecated member
 case class Annotation(
   name: String,
+  @deprecated("Lossy, the separator between parameters is not recoverable, use parameterList")
   parameters: Option[String],
   location: Option[Location] = None,
   parameterList: Option[ArraySeq[AnnotationParameter]] = None
@@ -23,17 +28,18 @@ case class Annotation(
   override def equals(obj: Any): Boolean = {
     val other = obj.asInstanceOf[Annotation]
     name.equalsIgnoreCase(other.name) &&
-    parameters.getOrElse("").equalsIgnoreCase(other.parameters.getOrElse(""))
-    // Note: location & parameterList intentionally excluded from equality. Equality is over the
-    // annotation as written, and annotations are compared across producers that populate only
-    // 'parameters', so including parameterList would change set/map behaviour for existing
-    // consumers. It would also be finer than 'parameters' alone, e.g. 'a=1 b=2' and 'a=1b=2' share
-    // a parameters string but not a parameterList.
+    parameters.getOrElse("").equalsIgnoreCase(other.parameters.getOrElse("")) &&
+    parameterList == other.parameterList
+    // Note: location intentionally excluded from equality, see also AnnotationParameter which
+    // excludes its own locations for the same reason.
   }
 
   override def hashCode(): Int = {
-    MurmurHash3.orderedHash(Seq(name.toLowerCase(), parameters.getOrElse("")))
-    // Note: location & parameterList intentionally excluded from hash
+    MurmurHash3.orderedHash(
+      Seq(name.toLowerCase(), parameters.getOrElse("").toLowerCase(), parameterList)
+    )
+    // Note: location intentionally excluded from hash. The parameters string is lowered here to
+    // match the case-insensitive comparison in equals, previously it was not.
   }
 
   override def toString: String = {

--- a/shared/src/main/scala/io/github/apexdevtools/types/base/Annotation.scala
+++ b/shared/src/main/scala/io/github/apexdevtools/types/base/Annotation.scala
@@ -3,7 +3,6 @@
  */
 package io.github.apexdevtools.types.base
 
-import scala.annotation.nowarn
 import scala.collection.immutable.ArraySeq
 import scala.util.hashing.MurmurHash3
 
@@ -12,38 +11,41 @@ import scala.util.hashing.MurmurHash3
   * `parameterList` is the parameter list as written, see [[AnnotationParameter]]. It is empty when
   * the annotation was written without parentheses and an empty sequence when they were written but
   * hold nothing.
-  *
-  * `parameters` is the same content as a single unparsed string and is deprecated. It is a
-  * concatenation of token contents, so it cannot represent the separator between two parameters,
-  * which is the whole point of reading them.
   */
-@nowarn("cat=deprecation") // this class necessarily still reads its own deprecated member
 case class Annotation(
   name: String,
-  @deprecated("Lossy, the separator between parameters is not recoverable, use parameterList")
-  parameters: Option[String],
-  location: Option[Location] = None,
-  parameterList: Option[ArraySeq[AnnotationParameter]] = None
+  parameterList: Option[ArraySeq[AnnotationParameter]] = None,
+  location: Option[Location] = None
 ) {
   override def equals(obj: Any): Boolean = {
     val other = obj.asInstanceOf[Annotation]
     name.equalsIgnoreCase(other.name) &&
-    parameters.getOrElse("").equalsIgnoreCase(other.parameters.getOrElse("")) &&
     parameterList == other.parameterList
-    // Note: location intentionally excluded from equality, see also AnnotationParameter which
-    // excludes its own locations for the same reason.
+    // Equality is over the annotation as written: its name, and the parameters in the order and
+    // form they were written in. Names and values are compared case-insensitively by
+    // AnnotationParameter, as Apex treats them.
+    // Note: location intentionally excluded, as it is on Modifier.
   }
 
   override def hashCode(): Int = {
-    MurmurHash3.orderedHash(
-      Seq(name.toLowerCase(), parameters.getOrElse("").toLowerCase(), parameterList)
-    )
-    // Note: location intentionally excluded from hash. The parameters string is lowered here to
-    // match the case-insensitive comparison in equals, previously it was not.
+    MurmurHash3.orderedHash(Seq(name.toLowerCase(), parameterList))
+    // Note: location intentionally excluded from hash
   }
 
+  /** Render the annotation as written, including the separators. Whitespace is normalised to a
+    * single space, so this is a faithful but not verbatim rendering of the source.
+    */
   override def toString: String = {
-    if (parameters.isDefined) s"@$name(${parameters.get})" else s"@$name"
+    parameterList match {
+      case None => s"@$name"
+      case Some(parameters) =>
+        val rendered = parameters
+          .map(parameter =>
+            parameter.precedingSeparator.map(_.text).getOrElse("") + parameter.toString
+          )
+          .mkString
+        s"@$name($rendered)"
+    }
   }
 }
 

--- a/shared/src/main/scala/io/github/apexdevtools/types/base/AnnotationParameter.scala
+++ b/shared/src/main/scala/io/github/apexdevtools/types/base/AnnotationParameter.scala
@@ -30,9 +30,8 @@ object AnnotationParameterSeparator {
   * argument of `@SuppressWarnings('PMD')`. Values are left uninterpreted, quotes and all, no
   * attempt is made to establish whether the name or value is legal for the annotation.
   *
-  * As with the unparsed `Annotation.parameters` string, the text of a value is a concatenation of
-  * token contents so any whitespace inside it is not preserved. Use `valueLocation` against the
-  * source if the exact text matters.
+  * The text of a value is a concatenation of token contents, so any whitespace inside it is not
+  * preserved. Use `valueLocation` against the source if the exact text matters.
   *
   * `precedingSeparator` is the separator written between this parameter and the one before it, it
   * is empty for the first parameter of a list.

--- a/shared/src/main/scala/io/github/apexdevtools/types/base/AnnotationParameter.scala
+++ b/shared/src/main/scala/io/github/apexdevtools/types/base/AnnotationParameter.scala
@@ -4,6 +4,7 @@
 package io.github.apexdevtools.types.base
 
 import scala.collection.immutable.ArraySeq
+import scala.util.hashing.MurmurHash3
 
 /** Separator written between two annotation parameters.
   *
@@ -44,6 +45,24 @@ final case class AnnotationParameter(
   valueLocation: Option[Location] = None,
   location: Option[Location] = None
 ) {
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case other: AnnotationParameter =>
+        name.isDefined == other.name.isDefined &&
+        name.getOrElse("").equalsIgnoreCase(other.name.getOrElse("")) &&
+        value.equalsIgnoreCase(other.value) &&
+        precedingSeparator == other.precedingSeparator
+      // Note: locations intentionally excluded from equality, as they are on Annotation and
+      // Modifier. Names and values are compared case-insensitively, as Apex treats them.
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = {
+    MurmurHash3.orderedHash(Seq(name.map(_.toLowerCase), value.toLowerCase, precedingSeparator))
+    // Note: locations intentionally excluded from hash
+  }
+
   override def toString: String = name.map(n => s"$n=$value").getOrElse(value)
 }
 

--- a/shared/src/test/scala/io/github/apexdevtools/oparser/AnnotationParameterTest.scala
+++ b/shared/src/test/scala/io/github/apexdevtools/oparser/AnnotationParameterTest.scala
@@ -7,8 +7,12 @@ import io.github.apexdevtools.types.base.AnnotationParameterSeparator.{Comma, Wh
 import io.github.apexdevtools.types.base.{Annotation, AnnotationParameter, Location}
 import org.scalatest.funspec.AnyFunSpec
 
+import scala.annotation.nowarn
+
 import java.nio.charset.StandardCharsets
 
+// The suite deliberately pins the behaviour of the deprecated 'parameters' string
+@nowarn("cat=deprecation")
 class AnnotationParameterTest extends AnyFunSpec {
 
   private var source: String = ""
@@ -192,12 +196,35 @@ class AnnotationParameterTest extends AnyFunSpec {
   }
 
   describe("equality") {
-    it("ignores the parameter list, as it does the location") {
-      val spaced = annotation("@AuraEnabled(cacheable=true scope='global')")
-      val hand   = Annotation(spaced.name, spaced.parameters)
+    it("still ignores locations") {
+      val first  = annotation("@AuraEnabled(cacheable=true scope='global')")
+      val second = annotation("\n\n  @AuraEnabled(cacheable=true scope='global')")
+      assert(first.location != second.location)
+      assert(first == second)
+      assert(first.hashCode() == second.hashCode())
+    }
+
+    it("uses the parameter list, so a lost separator is no longer equal") {
+      // Both have the same unparsed 'parameters' string, only the structure tells them apart
+      val separated = annotation("@Dummy(a=1 b=2)")
+      val run       = annotation("@Dummy(a=1b=2)")
+      assert(separated.parameters == run.parameters)
+      assert(separated.parameterList != run.parameterList)
+      assert(separated != run)
+    }
+
+    it("does not treat a hand-built annotation as equal to a parsed one") {
+      val parsed = annotation("@AuraEnabled(cacheable=true scope='global')")
+      val hand   = Annotation(parsed.name, parsed.parameters)
       assert(hand.parameterList.isEmpty)
-      assert(spaced == hand)
-      assert(spaced.hashCode() == hand.hashCode())
+      assert(parsed != hand)
+    }
+
+    it("ignores the case of names and values, as the unparsed string does") {
+      val lower = annotation("@AuraEnabled(cacheable=true scope='global')")
+      val upper = annotation("@auraenabled(CACHEABLE=TRUE SCOPE='GLOBAL')")
+      assert(lower == upper)
+      assert(lower.hashCode() == upper.hashCode())
     }
   }
 }

--- a/shared/src/test/scala/io/github/apexdevtools/oparser/AnnotationParameterTest.scala
+++ b/shared/src/test/scala/io/github/apexdevtools/oparser/AnnotationParameterTest.scala
@@ -39,15 +39,11 @@ class AnnotationParameterTest extends AnyFunSpec {
 
   describe("presence of a parameter list") {
     it("has none when written without parentheses") {
-      val a = annotation("@AuraEnabled")
-      assert(a.parameters.isEmpty)
-      assert(a.parameterList.isEmpty)
+      assert(annotation("@AuraEnabled").parameterList.isEmpty)
     }
 
     it("has an empty one when written with empty parentheses") {
-      val a = annotation("@AuraEnabled()")
-      assert(a.parameters.contains(""))
-      assert(a.parameterList.exists(_.isEmpty))
+      assert(annotation("@AuraEnabled()").parameterList.exists(_.isEmpty))
     }
   }
 
@@ -178,20 +174,33 @@ class AnnotationParameterTest extends AnyFunSpec {
     }
   }
 
-  describe("the unparsed parameters string") {
-    it("is unchanged for each form") {
-      assert(annotation("@AuraEnabled").parameters.isEmpty)
-      assert(annotation("@AuraEnabled()").parameters.contains(""))
-      assert(annotation("@SuppressWarnings('PMD')").parameters.contains("'PMD'"))
+  describe("rendering") {
+    it("renders the separator that was written") {
+      assert(annotation("@AuraEnabled").toString == "@AuraEnabled")
+      assert(annotation("@AuraEnabled()").toString == "@AuraEnabled()")
+      assert(annotation("@SuppressWarnings('PMD')").toString == "@SuppressWarnings('PMD')")
       assert(
-        annotation("@AuraEnabled(cacheable=true scope='global')").parameters
-          .contains("cacheable=truescope='global'")
+        annotation("@AuraEnabled(cacheable=true scope='global')").toString ==
+          "@AuraEnabled(cacheable=true scope='global')"
       )
       assert(
-        annotation("@AuraEnabled(cacheable=true, scope='global')").parameters
-          .contains("cacheable=true,scope='global'")
+        annotation("@AuraEnabled(cacheable=true, scope='global')").toString ==
+          "@AuraEnabled(cacheable=true,scope='global')"
       )
-      assert(annotation("@Dummy(a=f(1, 2) b=3)").parameters.contains("a=f(1,2)b=3"))
+      assert(
+        annotation("@AuraEnabled(cacheable=true,)").toString == "@AuraEnabled(cacheable=true,)"
+      )
+      assert(annotation("@Dummy(a=f(1, 2) b=3)").toString == "@Dummy(a=f(1,2) b=3)")
+    }
+
+    it("normalises whitespace rather than reproducing the source") {
+      assert(
+        annotation("@AuraEnabled( cacheable = true )").toString == "@AuraEnabled(cacheable=true)"
+      )
+      assert(
+        annotation("@AuraEnabled(cacheable=true\n    scope='global')").toString ==
+          "@AuraEnabled(cacheable=true scope='global')"
+      )
     }
   }
 
@@ -204,23 +213,22 @@ class AnnotationParameterTest extends AnyFunSpec {
       assert(first.hashCode() == second.hashCode())
     }
 
-    it("uses the parameter list, so a lost separator is no longer equal") {
-      // Both have the same unparsed 'parameters' string, only the structure tells them apart
+    it("tells apart lists that a flattened string could not") {
+      // Both flatten to the same text, only the structure separates them
       val separated = annotation("@Dummy(a=1 b=2)")
       val run       = annotation("@Dummy(a=1b=2)")
-      assert(separated.parameters == run.parameters)
-      assert(separated.parameterList != run.parameterList)
       assert(separated != run)
     }
 
-    it("does not treat a hand-built annotation as equal to a parsed one") {
-      val parsed = annotation("@AuraEnabled(cacheable=true scope='global')")
-      val hand   = Annotation(parsed.name, parsed.parameters)
-      assert(hand.parameterList.isEmpty)
-      assert(parsed != hand)
+    it("tells apart the separator that was used") {
+      assert(annotation("@Dummy(a=1 b=2)") != annotation("@Dummy(a=1, b=2)"))
     }
 
-    it("ignores the case of names and values, as the unparsed string does") {
+    it("does not treat an annotation with no parameter list as equal to one with an empty list") {
+      assert(Annotation("Dummy") != annotation("@Dummy()"))
+    }
+
+    it("ignores the case of names and values") {
       val lower = annotation("@AuraEnabled(cacheable=true scope='global')")
       val upper = annotation("@auraenabled(CACHEABLE=TRUE SCOPE='GLOBAL')")
       assert(lower == upper)

--- a/shared/src/test/scala/io/github/apexdevtools/oparser/DeclarationGeneratorHelper.scala
+++ b/shared/src/test/scala/io/github/apexdevtools/oparser/DeclarationGeneratorHelper.scala
@@ -6,6 +6,7 @@ package io.github.apexdevtools.oparser
 
 import io.github.apexdevtools.types.base.{
   Annotation,
+  AnnotationParameter,
   Location,
   Modifier,
   QualifiedName,
@@ -68,8 +69,12 @@ trait DeclarationGeneratorHelper {
     LocatableIdToken(token, Location.default)
   }
 
+  /* A parameter here is written as a single unnamed value, which is enough for these tests */
   def toAnnotation(ids: Array[String], parameter: Option[String]): Annotation = {
-    Annotation(toQName(ids).toString, parameter)
+    Annotation(
+      toQName(ids).toString,
+      parameter.map(value => ArraySeq(AnnotationParameter(None, value)))
+    )
   }
 
   def toQName(ids: Array[String]): QualifiedName = {


### PR DESCRIPTION
Follows #38. apex-parser 5.2.0 (apex-dev-tools/apex-parser#146) tightened the annotation grammar, which
both forces a small fix here and lets the ANTLR reference parser produce the structured form. On top of
that, `Annotation.parameters` is **removed** rather than deprecated: the only known consumer is apex-ls,
and we do not want the lossy view surviving into a release at all.

## 1–2. Bump and the compile break

`apex-parser` 5.1.0 → 5.2.0 (Test scope). `AnnotationContext.qualifiedName()` is now `id()`, so
`antlrAnnotation` no longer builds a `QualifiedName` from a dotted list.

## 3. The ANTLR reference parser now builds a real `parameterList`

It previously did `.getText` over `elementValue`/`elementValuePairs`. That drops whitespace exactly as
our own tokeniser does, and that accidental symmetry was the only reason the lossy string worked as a
comparison key at all.

5.2.0 exposes `elementValuePair` with `id` and `literal`, so the reference parser now produces the same
model ours does — name, value, locations, and the preceding separator taken from whether a `COMMA` token
sits between two pairs in the tree. Walking `ctx.children` in order gives exact adjacency rather than
having to infer it from token offsets.

## 4. `parameters` is removed

```scala
case class Annotation(
  name: String,
  parameterList: Option[ArraySeq[AnnotationParameter]] = None,
  location: Option[Location] = None
)
```

`parameterList` keeps the distinction `parameters` drew between `None` and `Some("")`: empty when the
annotation had no parentheses, an empty sequence when it had them but nothing inside.

**Equality and hashing** are over name and `parameterList` — by construction now, since there is nothing
else to compare on. `location` stays excluded, as on `Modifier`, and `AnnotationParameter` excludes its
own locations for the same reason (without that nothing would ever compare equal, since ANTLR locations
carry no byte offsets). Names and values compare case-insensitively, as the platform treats them and as
`parameters` was already compared.

What changes for a caller: two annotations whose flattened text coincides but whose structure differs —
`@Dummy(a=1 b=2)` and `@Dummy(a=1b=2)` both flattened to `a=1b=2` — are no longer equal, and neither are
lists that differ only in their separator.

**`toString` is rebuilt from `parameterList`**, and this is a visible output change:

| Source | Before | Now |
|---|---|---|
| `@AuraEnabled` | `@AuraEnabled` | `@AuraEnabled` |
| `@AuraEnabled()` | `@AuraEnabled()` | `@AuraEnabled()` |
| `@AuraEnabled(cacheable=true scope='global')` | `@AuraEnabled(cacheable=truescope='global')` | `@AuraEnabled(cacheable=true scope='global')` |
| `@AuraEnabled(cacheable=true, scope='global')` | `@AuraEnabled(cacheable=true,scope='global')` | `@AuraEnabled(cacheable=true,scope='global')` |
| `@AuraEnabled(cacheable=true,)` | `@AuraEnabled(cacheable=true,)` | `@AuraEnabled(cacheable=true,)` |
| `@AuraEnabled( cacheable = true )` | `@AuraEnabled(cacheable=true)` | `@AuraEnabled(cacheable=true)` |

The separator that was written now survives the round trip. Whitespace is normalised to a single space
and a comma renders without one, so the rendering is faithful but not verbatim — the scaladoc says so.
This flows into `IBodyDeclaration`/`IVariable`/`IMethodDeclaration` output, which include
`annotationsAndModifiers`, and so into the `TestTypeDeclarations` dumps that `SubsetComparator` compares
for inner types. Those comparisons are between two parsers that now both build `parameterList`, so they
still agree; a new `rendering` block in `AnnotationParameterTest` pins the table above.

The test helper `toAnnotation(ids, parameter)` keeps its `Option[String]` ergonomics and wraps the string
as a single unnamed parameter, which preserves the intent of every `SubsetComparatorTest` case using it.

## 5. The sample comparison is now structural — and it agrees

This is the part worth reading. Comparing on `parameterList` rather than a flattened string means the
two parsers must agree on the name, value, order and **separator** of every annotation parameter across
the corpus, not merely produce the same whitespace-stripped text.

**No disagreements surfaced.** 6,262 sample files, all comparisons pass. Combined with `toString` now
being part of the inner-type comparison, that is a second, independently written parser agreeing with
ours on the structure of every annotation in the corpus.

## 6. The permissive-parser divergence: investigated, leave it alone

Our `parseAnnotation` still accepts `@Schema.AuraEnabled` and is permissive about values, where ANTLR
5.2.0 is not. **It cannot make the comparison disagree.** `AntlrParser.parse` throws on the first syntax
error, so a file ANTLR rejects yields `None` and `SampleTest` skips the comparison. The only assertion in
the other direction is *"Outline parser failed when ANTLR parsed"*, which a **narrowing** of the ANTLR
grammar cannot newly trigger. The real risk is not a wrong answer, it is silently losing comparison
coverage — so I measured that under both versions:

| | 5.1.0 | 5.2.0 |
|---|---|---|
| Sample files | 6,262 | 6,262 |
| Outline parser accepts | 6,244 | 6,244 |
| **Both accept (compared)** | **6,234** | **6,234** |
| Outline accepts, ANTLR rejects | 10 | 10 |

Identical. The 10 files ANTLR rejects all fail with `token recognition error at: '%'` — nothing to do
with annotations, and pre-existing. A regex sweep for `@Name.Name` returns 871 hits, every one an email
address inside a string literal; there is no `@Namespace.Annotation` anywhere in the corpus.

**Recommendation: no change.** The outline parser is a deliberately fast outline pass, not a validating
parser, and the forms it over-accepts do not compile on the platform anyway — apex-ls#541 will diagnose
them with far better messages than a parse failure. Worth doing separately if we want a guard:
`SampleTest` skips silently when ANTLR fails, so a future grammar change could quietly erode coverage.
Asserting a floor on the both-accept count would catch that. Not done here, as it changes the harness
rather than this feature.

## Two things for release prep, not acted on here

- **Versioning.** Removing a public field from a published case class is a breaking API change.
  outline-parser is at 2.0.0 with `versionScheme := "strict"`, so whether this lands as 2.1.0 or 3.0.0 is
  a call to make at release prep. Flagging it so it is not missed.
- **apex-ls can no longer bump outline-parser as a version-only change.** It reads
  `opA.parameters.getOrElse("")` in `OutlineParserModifierOps` and will not compile until it migrates to
  `parameterList`. That is expected — apex-ls's next bump already needs code changes for apex-parser
  5.2.0 — but the two have to land together.

## Verification

JDK 17, `apex-samples` pinned at `v1.4.0`:

- `sbt scalafmtCheck` — pass
- `sbt build` — pass (JVM jar and Scala.js full opt)
- `sbt parserJVM/test` — 6344 passed, 0 failed, including 6,262 sample comparisons with `SAMPLES` set
- `sbt parserJS/test` — 81 passed, 0 failed
