### PR TITLE
chore: release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # outline-parser - Changelog
 
-## Unreleased
+## 2.1.0 - 2026-08-23
 
 ### API
 
@@ -20,7 +20,8 @@
 
 ### Build & dependencies
 
-- Updated the `apex-parser` test dependency to 5.2.0, which tightens the annotation grammar. The ANTLR reference parser used by the sample comparison now builds a full `parameterList`, so the structured form is compared against a second parser across the sample corpus rather than only being produced.
+- Updated the `apex-parser` dependency to 5.2.0, which tightens the annotation grammar: `build.sbt` (JVM `Test` scope) and `js/npm/package.json` (`^5.2.0`), with `js/npm/package-lock.json` regenerated. The ANTLR reference parser used by the sample comparison now builds a full `parameterList`, so the structured form is compared against a second parser across the sample corpus rather than only being produced.
+  - apex-parser is a test and dev dependency here, so this does not change the published outline-parser artifacts, only the test toolchain.
 
 ## 2.0.0 - 2026-07-03
 

--- a/js/npm/package-lock.json
+++ b/js/npm/package-lock.json
@@ -6,16 +6,16 @@
     "": {
       "name": "@apexdevtools/outline-parser",
       "devDependencies": {
-        "@apexdevtools/apex-parser": "^5.1.0"
+        "@apexdevtools/apex-parser": "^5.2.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@apexdevtools/apex-parser": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@apexdevtools/apex-parser/-/apex-parser-5.1.0.tgz",
-      "integrity": "sha512-DPThB5oMnJ9b62weMpufGQfJjtZ+5UHP5Ne8nOqsDDCAVP3P2yRL80p1qX5BpPxyOowhTJ9RF/3qhat0vCrv4g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@apexdevtools/apex-parser/-/apex-parser-5.2.0.tgz",
+      "integrity": "sha512-6OwE46CAi6Y8q1Wz1k5dMrQR/awPqI4ryXcgYZaVx4tMUbfv4+n2ezUF7Tm0EOypXleuPwKqaZuDxlP486HXlA==",
       "bundleDependencies": [
         "antlr4"
       ],
@@ -40,9 +40,9 @@
   },
   "dependencies": {
     "@apexdevtools/apex-parser": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@apexdevtools/apex-parser/-/apex-parser-5.1.0.tgz",
-      "integrity": "sha512-DPThB5oMnJ9b62weMpufGQfJjtZ+5UHP5Ne8nOqsDDCAVP3P2yRL80p1qX5BpPxyOowhTJ9RF/3qhat0vCrv4g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@apexdevtools/apex-parser/-/apex-parser-5.2.0.tgz",
+      "integrity": "sha512-6OwE46CAi6Y8q1Wz1k5dMrQR/awPqI4ryXcgYZaVx4tMUbfv4+n2ezUF7Tm0EOypXleuPwKqaZuDxlP486HXlA==",
       "dev": true,
       "requires": {
         "antlr4": "4.13.2"

--- a/js/npm/package.json
+++ b/js/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@apexdevtools/outline-parser",
   "devDependencies": {
-    "@apexdevtools/apex-parser": "^5.1.0"
+    "@apexdevtools/apex-parser": "^5.2.0"
   },
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"


### PR DESCRIPTION
Release prep for **v2.1.0**. Closes #40.

Collects #36, #38 and #39 and picks up the released **apex-parser 5.2.0** (test/dev-only dependency).

## Changes

- **CHANGELOG**: `## Unreleased` → `## 2.1.0 - 2026-08-23`. Content is as written in the feature PRs;
  reviewed as release notes rather than rewritten. The one addition is a note that apex-parser is a test
  and dev dependency here, so the bump does not change the published artifacts.
- **apex-parser dev dep** `^5.1.0 → ^5.2.0` in `js/npm/package.json`, with `js/npm/package-lock.json`
  regenerated. `build.sbt` was already on 5.2.0 from #39, so this brings the two halves back into
  agreement. The caret resolved 5.2.0 in practice, so nothing was broken — the lock file was the part
  actually pinned, at 5.1.0 exactly.

The `(BREAKING)` labels stay as they are. 2.1.0 is right by the project's convention of reserving majors
for build-environment or large-scale changes, and `versionScheme` is `strict`, so a consumer cannot
silently evict onto an incompatible version — a mismatch is a build error, not a runtime surprise.

I checked for anything else carrying a version or an apex-parser reference before assuming those were
the only files. There is nothing else: no `version.sbt`, no version in `build.sbt` (`sbt-ci-release`
derives it from the tag, and the only `version :=` is inside the local `pack` command, which takes it as
an argument), and the README's "Starting with version 2.0.0" is a historical statement that is still
correct. Nothing added.

## Validation (matches CI Build.yml)

JDK 17, `apex-samples` at `v1.4.0`:

- `sbt scalafmtCheck` → success
- `sbt build` → success (JS full-opt via Closure, 0 errors / 0 warnings; JVM jar)
- `SAMPLES=apex-samples@v1.4.0 sbt test` → **6425 tests passed, 0 failed** (JVM 6344 across 6 suites,
  including the 6,262 sample comparisons; JS 81 across 5 suites)

`apex-samples` was verified at the pin before running (`git rev-parse HEAD` == `git rev-parse
v1.4.0^{commit}` == `1556acf`) and left untouched afterwards.

## Release gate

**apex-ls cannot be validated ahead of this release.** It consumes the published artifact, and it needs
code changes for both this release and apex-parser 5.2.0 — `OutlineParserModifierOps` reads
`opA.parameters.getOrElse("")`, which no longer exists, and `cst/CST.scala` uses
`annotation.qualifiedName()` (now `id()`) and builds an `ElementValueArrayInitializer` CST on a context
class that is no longer generated. That work is apex-dev-tools/apex-ls#541 and follows the release
rather than gating it.

This differs from the 2.0.0 gate in #33, where apex-ls already pinned the beta and downstream
integration was validated in advance. Here it cannot be, by construction.

## After merge

Create GitHub Release `v2.1.0` (not a pre-release) to trigger `PublishMaven.yml` (`sbt ci-release`),
publishing 2.1.0 to Maven Central for both JS and JVM.

If publishing fails, check the org's Maven signing key first — it expires annually and the failure
presents as a missing secret rather than an expired key.

Then apex-ls#541 bumps `outline-parser` 2.0.0 → 2.1.0 and `apex-parser` 5.1.0 → 5.2.0 together, with the
code changes above.
